### PR TITLE
add defaultLoggerName to Client

### DIFF
--- a/client.go
+++ b/client.go
@@ -367,6 +367,9 @@ type Client struct {
 	// DropHandler is called when a packet is dropped because the buffer is full.
 	DropHandler func(*Packet)
 
+	// default logger name (leave empty for 'root')
+	DefaultLoggerName string
+
 	// Context that will get appending to all packets
 	context *context
 
@@ -521,7 +524,13 @@ func (client *Client) Capture(packet *Packet, captureTags map[string]string) (ev
 	projectID := client.projectID
 	release := client.release
 	environment := client.environment
+	defaultLoggerName := client.DefaultLoggerName
 	client.mu.RUnlock()
+
+	// set the global logger name on the packet if we must
+	if packet.Logger == "" && defaultLoggerName != "" {
+		packet.Logger = defaultLoggerName
+	}
 
 	err := packet.Init(projectID)
 	if err != nil {


### PR DESCRIPTION
add the ability to set a `DefaultLoggerName` on the raven client. This default logger name is then set on the packet before Init (but only in case the packet has no Logger name set already)

If the `DefaultLoggerName` is empty (default), there's no change from the current behaviour.

useful for services that don't want to use the package name as the logger name, it makes more sense to set this once and forget about it.
